### PR TITLE
Parse metadata from filename and allow file filtering

### DIFF
--- a/src/medberg/__init__.py
+++ b/src/medberg/__init__.py
@@ -1,1 +1,1 @@
-from .securesite import SecureSite, File
+from .securesite import SecureSite

--- a/src/medberg/exceptions.py
+++ b/src/medberg/exceptions.py
@@ -15,3 +15,11 @@ class InvalidFileException(Exception):
     def __init__(self):
         message = "The specified file was not found on the secure site."
         super().__init__(message)
+
+
+class InvalidFilterException(Exception):
+    """Raised when an invalid filter is applied to a list of Files."""
+
+    def __init__(self):
+        message = "The specified filter is invalid. Please ensure the filter value is a string, integer, callable, or valid iterable (list, tuple)."
+        super().__init__(message)

--- a/src/medberg/file.py
+++ b/src/medberg/file.py
@@ -1,0 +1,25 @@
+from datetime import datetime
+from pathlib import Path
+
+
+class File:
+    """Represents a file available on the secure site.
+
+    File instances are created automatically when a connection to the secure
+    site is established and the list of available files is parsed. They should
+    not be created manually.
+    """
+
+    def __init__(self, conn, name: str, filesize: str, date: datetime):
+        self._conn = conn
+        self.name = name
+        self.filesize = filesize
+        self.date = date
+
+    def __repr__(self) -> str:
+        date = datetime.strftime(self.date, "%m/%d/%Y")
+        return f"File(name={self.name}, filesize={self.filesize=}, {date=})"
+
+    def get(self, *args, **kwargs) -> Path:
+        """Download a file from the Amerisource secure site."""
+        return self._conn.get_file(file=self, *args, **kwargs)

--- a/src/medberg/file.py
+++ b/src/medberg/file.py
@@ -1,3 +1,4 @@
+import re
 from datetime import datetime
 from pathlib import Path
 
@@ -16,9 +17,51 @@ class File:
         self.filesize = filesize
         self.date = date
 
+        self._filename_parts = self._parse_filename()
+
     def __repr__(self) -> str:
         date = datetime.strftime(self.date, "%m/%d/%Y")
         return f"File(name={self.name}, filesize={self.filesize=}, {date=})"
+
+    def _parse_filename(self) -> dict[str, str | None]:
+        """Try to parse metadata from the file's name.
+
+        If present, will save account type, file specification, and account
+        number in a dictionary that can be accessed with class properties.
+        """
+        filename_pattern = r"(?P<account_type>^|^340B|^WAC)_?(?P<specification>(?:037A|037A|039A|039A|77AX|037G|077A)X?M?)?_?(?P<account_number>\d{9})_?\d{4,6}\.TXT$"
+        parts = {
+            "account_type": None,
+            "specification": None,
+            "account_number": None,
+        }
+
+        name_matches = re.match(filename_pattern, self.name)
+        if name_matches:
+            parts.update(name_matches.groupdict())
+
+        # Regex returns empty strings for unmatched groups. We convert them to
+        # None for cleanliness.
+        for key, value in parts.items():
+            if value == "":
+                parts[key] = None
+
+        return parts
+
+    @property
+    def account_type(self) -> str | None:
+        """Get account type (e.g., 340B, WAC) if present in filename."""
+        return self._filename_parts.get("account_type")
+
+    @property
+    def specification(self) -> str | None:
+        """Get file spec (e.g., 037, 039) if present in filename."""
+        return self._filename_parts.get("specification")
+
+    @property
+    def account_number(self) -> str | None:
+        """Get account number if present in filename."""
+        return self._filename_parts.get("account_number")
 
     def get(self, *args, **kwargs) -> Path:
         """Download a file from the Amerisource secure site."""

--- a/src/medberg/securesite.py
+++ b/src/medberg/securesite.py
@@ -154,10 +154,10 @@ class SecureSite:
         return latest
 
     def get_file(
-            self,
-            file: File | str,
-            save_dir: str | Path | None = None,
-            save_name: str | None = None,
+        self,
+        file: File | str,
+        save_dir: str | Path | None = None,
+        save_name: str | None = None,
     ) -> Path:
         """Download a file from the Amerisource secure site.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+import os
+
+import pytest
+from dotenv import load_dotenv
+
+from medberg import SecureSite
+
+
+@pytest.fixture(scope="session")
+def connection():
+    load_dotenv()
+    username = os.getenv("AMERISOURCE_USERNAME")
+    password = os.getenv("AMERISOURCE_PASSWORD")
+    return SecureSite(username, password)

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -99,6 +99,10 @@ def test_match_strings(file):
     assert file.matches("filesize", "1.2M")
     assert file.matches("account_type", "340B")
     assert file.matches("specification", "037AM")
+    assert file.matches("specification", "*37AM")
+    assert file.matches("specification", "*037AM")
+    assert file.matches("specification", "037*")
+    assert file.matches("specification", "037AM*")
     assert file.matches("account_number", "123456789")
 
 
@@ -107,6 +111,8 @@ def test_mismatch_strings(file):
     assert file.matches("filesize", "10M") == False
     assert file.matches("account_type", "WAC") == False
     assert file.matches("specification", "039A") == False
+    assert file.matches("specification", "*39A") == False
+    assert file.matches("specification", "039*") == False
     assert file.matches("account_number", "987654321") == False
 
 

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -82,3 +82,35 @@ def test_filename_account_number(test_filename):
         date=datetime.now(),
     )
     assert f.account_number == "123456789"
+
+
+@pytest.fixture(scope="module")
+def file():
+    return File(
+        conn=None,
+        name="340B037AM1234567890101.TXT",
+        filesize="1.2M",
+        date=datetime.now(),
+    )
+
+
+def test_match_strings(file):
+    assert file.matches("name", "340B037AM1234567890101.TXT")
+    assert file.matches("filesize", "1.2M")
+    assert file.matches("account_type", "340B")
+    assert file.matches("specification", "037AM")
+    assert file.matches("account_number", "123456789")
+
+
+def test_match_integers(file):
+    assert file.matches("account_number", 123456789)
+
+
+def test_match_callable(file):
+    past_date = datetime(2025, 1, 1, 0, 0, 0)
+    assert file.matches("date", lambda x: x > past_date)
+
+
+def test_match_iterable(file):
+    account_types = ["340B", "GPO", "WAC"]
+    assert file.matches("account_type", account_types)

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -102,8 +102,20 @@ def test_match_strings(file):
     assert file.matches("account_number", "123456789")
 
 
+def test_mismatch_strings(file):
+    assert file.matches("name", "340B037AM9876543210101.TXT") == False
+    assert file.matches("filesize", "10M") == False
+    assert file.matches("account_type", "WAC") == False
+    assert file.matches("specification", "039A") == False
+    assert file.matches("account_number", "987654321") == False
+
+
 def test_match_integers(file):
     assert file.matches("account_number", 123456789)
+
+
+def test_mismatch_integers(file):
+    assert file.matches("account_number", 987654321) == False
 
 
 def test_match_callable(file):
@@ -111,6 +123,38 @@ def test_match_callable(file):
     assert file.matches("date", lambda x: x > past_date)
 
 
+def test_mismatch_callable(file):
+    past_date = datetime(2025, 1, 1, 0, 0, 0)
+    assert file.matches("date", lambda x: x < past_date) == False
+
+
 def test_match_iterable(file):
     account_types = ["340B", "GPO", "WAC"]
     assert file.matches("account_type", account_types)
+
+
+def test_mismatch_iterable(file):
+    account_types = ["GPO", "WAC"]
+    assert file.matches("account_type", account_types) == False
+
+
+def test_match_none():
+    f = File(
+        conn=None,
+        name="1234567890101.TXT",
+        filesize="1.2M",
+        date=datetime.now(),
+    )
+    assert f.matches("account_type", None)
+    assert f.matches("specification", None)
+
+
+def test_mismatch_none():
+    f = File(
+        conn=None,
+        name="1234567890101.TXT",
+        filesize="1.2M",
+        date=datetime.now(),
+    )
+    assert f.matches("account_number", None) == False
+    assert f.matches("filesize", None) == False

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -1,0 +1,84 @@
+from datetime import datetime
+
+import pytest
+
+from medberg.file import File
+
+
+def test_file_download(connection, tmp_path):
+    test_file = connection.files[0]
+    test_file.get(save_dir=tmp_path)
+
+    with open(tmp_path / test_file.name) as f:
+        assert f.read() != ""
+
+
+def test_file_download_name_change(connection, tmp_path):
+    test_file = connection.files[0]
+    test_file.get(save_dir=tmp_path, save_name="test.txt")
+
+    with open(tmp_path / "test.txt") as f:
+        assert f.read() != ""
+
+
+@pytest.mark.parametrize(
+    "test_filename, expected",
+    [
+        ("340B037AM1234567890101.TXT", "340B"),
+        ("037AM1234567890101.TXT", None),
+        ("039A_123456789_0101.TXT", None),
+        ("WAC77AX1234567890101.TXT", "WAC"),
+        ("123456789010125.TXT", None),
+        ("WAC_037AM_1234567890101.TXT", "WAC"),
+    ],
+)
+def test_filename_parse_account_type(test_filename, expected):
+    f = File(
+        conn=None,
+        name=test_filename,
+        filesize="1.2M",
+        date=datetime.now(),
+    )
+    assert f.account_type == expected
+
+
+@pytest.mark.parametrize(
+    "test_filename, expected",
+    [
+        ("340B037AM1234567890101.TXT", "037AM"),
+        ("037AM1234567890101.TXT", "037AM"),
+        ("039A_123456789_0101.TXT", "039A"),
+        ("WAC77AX1234567890101.TXT", "77AX"),
+        ("123456789010125.TXT", None),
+        ("WAC_037AM_1234567890101.TXT", "037AM"),
+    ],
+)
+def test_filename_parse_specification(test_filename, expected):
+    f = File(
+        conn=None,
+        name=test_filename,
+        filesize="1.2M",
+        date=datetime.now(),
+    )
+    assert f.specification == expected
+
+
+@pytest.mark.parametrize(
+    "test_filename",
+    [
+        "340B037AM1234567890101.TXT",
+        "037AM1234567890101.TXT",
+        "039A_123456789_0101.TXT",
+        "WAC77AX1234567890101.TXT",
+        "123456789010125.TXT",
+        "WAC_037AM_1234567890101.TXT",
+    ],
+)
+def test_filename_account_number(test_filename):
+    f = File(
+        conn=None,
+        name=test_filename,
+        filesize="1.2M",
+        date=datetime.now(),
+    )
+    assert f.account_number == "123456789"

--- a/tests/test_securesite.py
+++ b/tests/test_securesite.py
@@ -1,22 +1,7 @@
-import os
-
 import pytest
-from dotenv import load_dotenv
 
 from medberg import SecureSite
 from medberg.exceptions import LoginException, InvalidFileException
-
-
-@pytest.fixture(scope="session", autouse=True)
-def load_env():
-    load_dotenv()
-
-
-@pytest.fixture(scope="session")
-def connection():
-    username = os.getenv("AMERISOURCE_USERNAME")
-    password = os.getenv("AMERISOURCE_PASSWORD")
-    return SecureSite(username, password)
 
 
 def test_secure_site_auth(connection):
@@ -26,22 +11,6 @@ def test_secure_site_auth(connection):
 def test_secure_site_bad_auth():
     with pytest.raises(LoginException):
         conn = SecureSite("", "")
-
-
-def test_file_download(connection, tmp_path):
-    test_file = connection.files[0]
-    test_file.get(save_dir=tmp_path)
-
-    with open(tmp_path / test_file.name) as f:
-        assert f.read() != ""
-
-
-def test_file_download_name_change(connection, tmp_path):
-    test_file = connection.files[0]
-    test_file.get(save_dir=tmp_path, save_name="test.txt")
-
-    with open(tmp_path / "test.txt") as f:
-        assert f.read() != ""
 
 
 def test_file_download_by_name(connection, tmp_path):


### PR DESCRIPTION
When the SecureSite class is instantiated and the list of files is generated, attempt to parse additional metadata (account type, account number, and file specification) from the filename, if present. Additionally, allow filtering of the SecureSite.files list based on File properties. This fixes #1.