### PR TITLE
Allow row-level filtering

### DIFF
--- a/src/medberg/exceptions.py
+++ b/src/medberg/exceptions.py
@@ -23,3 +23,18 @@ class InvalidFilterException(Exception):
     def __init__(self):
         message = "The specified filter is invalid. Please ensure the filter value is a string, integer, callable, or valid iterable (list, tuple)."
         super().__init__(message)
+
+
+class MissingRowPatternException(Exception):
+    """Raised when attempting to parse a file without a row pattern."""
+
+    def __init__(self):
+        message = "A row pattern must be specified before attempting to parse a file. A pattern could not be automatically determined. Set one manually to continue."
+
+
+class EmptyBufferException(Exception):
+    """Raised when attempting to dump am empty buffer to disk."""
+
+    def __init__(self):
+        message = "There was an error loading the saved file. To prevent data loss, no changes to the file have been made."
+        super().__init__(message)

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -210,6 +210,7 @@ def test_filter(tmp_path):
         f.write(
             "00000000000111111  222222222333333333\n"
             "44444444444555555  666666666777777777\n"
+            "44444444444888888  999999999000000000\n"
         )
 
     test_file = File(
@@ -222,6 +223,8 @@ def test_filter(tmp_path):
     test_file.row_pattern = RowPattern.ICS_039A
     with test_file as f:
         f.filter_(lambda x: x.parts["ndc11"] == "44444444444")
+        f.filter_(lambda x: x.parts["item_id"] == "555555")
 
     assert len(f._row_buffer) == 1
     assert f._row_buffer[0].parts["ndc11"] == "44444444444"
+    assert f._row_buffer[0].parts["item_id"] == "555555"


### PR DESCRIPTION
Using the `File.filter_()` method, allow row-level manipulation of downloaded files